### PR TITLE
Add vi-style search popup for clipboard history

### DIFF
--- a/CLCL.vcxproj
+++ b/CLCL.vcxproj
@@ -19,13 +19,13 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v141_xp</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v141_xp</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/CLCL.vcxproj
+++ b/CLCL.vcxproj
@@ -164,6 +164,7 @@
     <ClCompile Include="OleDragDrop.c" />
     <ClCompile Include="Profile.c" />
     <ClCompile Include="Regist.c" />
+    <ClCompile Include="Search.c" />
     <ClCompile Include="SelectFolder.c" />
     <ClCompile Include="SelectFormat.c" />
     <ClCompile Include="SendKey.c" />
@@ -217,6 +218,7 @@
     <ClInclude Include="Profile.h" />
     <ClInclude Include="Regist.h" />
     <ClInclude Include="resource.h" />
+    <ClInclude Include="Search.h" />
     <ClInclude Include="SelectFolder.h" />
     <ClInclude Include="SelectFormat.h" />
     <ClInclude Include="SendKey.h" />

--- a/CLCLHook/CLCLHook.vcxproj
+++ b/CLCLHook/CLCLHook.vcxproj
@@ -14,18 +14,18 @@
     <SccProjectName />
     <SccLocalPath />
     <ProjectGuid>{455A6168-29F8-4650-BD35-E66044755A30}</ProjectGuid>
-    <WindowsTargetPlatformVersion>7.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v141_xp</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v141_xp</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>

--- a/CLCLSet/CLCLSet.vcxproj
+++ b/CLCLSet/CLCLSet.vcxproj
@@ -14,18 +14,18 @@
     <SccProjectName />
     <SccLocalPath />
     <ProjectGuid>{F701700D-6556-4BB3-BA90-5709B614FD40}</ProjectGuid>
-    <WindowsTargetPlatformVersion>7.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v141_xp</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v141_xp</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,38 @@
+# CLCL - build helpers for WSL
+#
+# The real work lives in scripts/build-wsl.sh (which also runs standalone);
+# .EXPORT_ALL_VARIABLES hands it the knobs below as environment variables.
+
+CONFIG    ?= Release
+PLATFORM  ?= x86
+# Empty: the .vcxproj files decide. Override to build against another toolset,
+# e.g. TOOLSET=v145, or TOOLSET=v141_xp SDK=7.0 for the original XP config.
+TOOLSET   ?=
+SDK       ?=
+WIN_BUILD ?= /mnt/c/temp/clcl-build
+VSWHERE   ?= /mnt/c/Program Files (x86)/Microsoft Visual Studio/Installer/vswhere.exe
+ARTIFACTS ?= CLCL.exe CLCLHook.dll CLCLSet.exe
+
+.ONESHELL:
+.EXPORT_ALL_VARIABLES:
+.NOTPARALLEL:
+
+# .ONESHELL feeds a whole recipe to one shell, and the default `sh -c` only
+# reports the last line's status. -e restores per-line failure.
+.SHELLFLAGS := -eu -c
+
+.PHONY: help build-wsl clean-wsl
+.DEFAULT_GOAL := help
+
+help:
+	@echo 'make build-wsl   build $(ARTIFACTS) into ./$(CONFIG)'
+	@echo 'make clean-wsl   remove ./Release ./Debug and $(WIN_BUILD)'
+	@echo
+	@echo 'Overridable: CONFIG=$(CONFIG) PLATFORM=$(PLATFORM) WIN_BUILD=$(WIN_BUILD)'
+	@echo '             TOOLSET/SDK (empty = as configured in the .vcxproj files)'
+
+build-wsl:
+	@./scripts/build-wsl.sh
+
+clean-wsl:
+	rm -rf Release Debug "$(WIN_BUILD)"

--- a/Search.c
+++ b/Search.c
@@ -45,6 +45,7 @@ static HWND hListBox;
 static WNDPROC origListBoxProc;
 static WNDPROC origEditProc;
 static HFONT hSearchFont;
+static BOOL search_closing;
 
 // Dynamic array mapping listbox index to DATA_INFO*
 static DATA_INFO **search_items;
@@ -60,6 +61,7 @@ static void search_collect(DATA_INFO *di, const TCHAR *filter);
 static void search_add_item(DATA_INFO *di, const TCHAR *title);
 static TCHAR *search_get_title(DATA_INFO *di);
 static void search_select_item(void);
+static void search_close(void);
 static HFONT search_create_font(void);
 
 /*
@@ -206,6 +208,22 @@ static void search_populate(const TCHAR *filter)
 }
 
 /*
+ * search_close - close the popup, keeping the result already decided
+ *
+ * DestroyWindow deactivates the popup first, so WM_ACTIVATE / WA_INACTIVE
+ * arrives before WM_DESTROY. The flag keeps that handler from treating our
+ * own teardown as a click-away and clearing search_result.
+ */
+static void search_close(void)
+{
+	if (search_closing == TRUE) {
+		return;
+	}
+	search_closing = TRUE;
+	DestroyWindow(hSearchWnd);
+}
+
+/*
  * search_select_item - select the current listbox item and close
  */
 static void search_select_item(void)
@@ -218,7 +236,7 @@ static void search_select_item(void)
 	} else {
 		search_result = NULL;
 	}
-	DestroyWindow(hSearchWnd);
+	search_close();
 }
 
 /*
@@ -237,7 +255,7 @@ static LRESULT CALLBACK listbox_subproc(HWND hWnd, UINT msg, WPARAM wParam, LPAR
 
 		case VK_ESCAPE:
 			search_result = NULL;
-			DestroyWindow(hSearchWnd);
+			search_close();
 			return 0;
 
 		case VK_OEM_2:
@@ -308,7 +326,7 @@ static LRESULT CALLBACK edit_subproc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM 
 
 		case VK_ESCAPE:
 			search_result = NULL;
-			DestroyWindow(hSearchWnd);
+			search_close();
 			return 0;
 
 		case VK_DOWN:
@@ -400,10 +418,10 @@ static LRESULT CALLBACK search_proc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM l
 		break;
 
 	case WM_ACTIVATE:
-		if (LOWORD(wParam) == WA_INACTIVE) {
+		if (LOWORD(wParam) == WA_INACTIVE && search_closing == FALSE) {
 			// Lost focus - close like a menu
 			search_result = NULL;
-			DestroyWindow(hWnd);
+			search_close();
 		}
 		break;
 
@@ -451,6 +469,7 @@ DATA_INFO *search_popup_show(const HWND hWnd, DATA_INFO *history_root)
 
 	search_history_root = history_root;
 	search_result = NULL;
+	search_closing = FALSE;
 
 	// Position at cursor
 	GetCursorPos(&pos);

--- a/Search.c
+++ b/Search.c
@@ -1,0 +1,495 @@
+/*
+ * CLCL
+ *
+ * Search.c
+ *
+ * Search popup for clipboard history - filter and select items by keyword
+ */
+
+/* Include Files */
+#define _INC_OLE
+#include <windows.h>
+#undef  _INC_OLE
+#include <tchar.h>
+#include <shlwapi.h>
+
+#include "General.h"
+#include "Memory.h"
+#include "Data.h"
+#include "Ini.h"
+#include "Format.h"
+#include "Font.h"
+#include "Search.h"
+
+/* Define */
+#define SEARCH_WIDTH					400
+#define SEARCH_HEIGHT					350
+#define SEARCH_EDIT_HEIGHT				24
+#define SEARCH_MARGIN					4
+
+#define IDC_SEARCH_EDIT					1
+#define IDC_SEARCH_LIST					2
+
+#define SEARCH_INIT_CAPACITY			256
+
+/* Global Variables */
+extern HINSTANCE hInst;
+extern OPTION_INFO option;
+
+/* Local Variables */
+static DATA_INFO *search_result;
+static DATA_INFO *search_history_root;
+static HWND hSearchWnd;
+static HWND hEditCtrl;
+static HWND hListBox;
+static WNDPROC origListBoxProc;
+static WNDPROC origEditProc;
+static HFONT hSearchFont;
+
+// Dynamic array mapping listbox index to DATA_INFO*
+static DATA_INFO **search_items;
+static int search_item_count;
+static int search_item_capacity;
+
+/* Local Function Prototypes */
+static LRESULT CALLBACK search_proc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam);
+static LRESULT CALLBACK listbox_subproc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam);
+static LRESULT CALLBACK edit_subproc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam);
+static void search_populate(const TCHAR *filter);
+static void search_collect(DATA_INFO *di, const TCHAR *filter);
+static void search_add_item(DATA_INFO *di, const TCHAR *title);
+static TCHAR *search_get_title(DATA_INFO *di);
+static void search_select_item(void);
+static HFONT search_create_font(void);
+
+/*
+ * search_regist - register window class
+ */
+BOOL search_regist(const HINSTANCE hInstance)
+{
+	WNDCLASS wc;
+
+	wc.style = CS_HREDRAW | CS_VREDRAW;
+	wc.lpfnWndProc = (WNDPROC)search_proc;
+	wc.cbClsExtra = 0;
+	wc.cbWndExtra = 0;
+	wc.hInstance = hInstance;
+	wc.hIcon = NULL;
+	wc.hCursor = LoadCursor(NULL, IDC_ARROW);
+	wc.hbrBackground = (HBRUSH)(COLOR_WINDOW + 1);
+	wc.lpszMenuName = NULL;
+	wc.lpszClassName = SEARCH_WND_CLASS;
+	return RegisterClass(&wc);
+}
+
+/*
+ * search_create_font - create font for search controls
+ */
+static HFONT search_create_font(void)
+{
+	NONCLIENTMETRICS ncMetrics;
+
+	if (*option.menu_font_name != TEXT('\0')) {
+		return font_create(option.menu_font_name, option.menu_font_size, option.menu_font_charset,
+			option.menu_font_weight, (option.menu_font_italic == 0) ? FALSE : TRUE, FALSE);
+	}
+
+	ncMetrics.cbSize = sizeof(NONCLIENTMETRICS);
+	if (SystemParametersInfo(SPI_GETNONCLIENTMETRICS,
+		sizeof(NONCLIENTMETRICS), &ncMetrics, 0) == FALSE) {
+		return NULL;
+	}
+	return CreateFontIndirect(&ncMetrics.lfMenuFont);
+}
+
+/*
+ * search_get_title - get display title for a DATA_INFO
+ */
+static TCHAR *search_get_title(DATA_INFO *di)
+{
+	DATA_INFO *show_di;
+
+	if (di == NULL) {
+		return NULL;
+	}
+	if (di->title != NULL && lstrcmp(di->title, TEXT("-")) != 0) {
+		return di->title;
+	}
+	if (di->type == TYPE_ITEM) {
+		show_di = format_get_priority_highest(di);
+		if (show_di != NULL) {
+			format_get_menu_title(show_di);
+			if (show_di->menu_title != NULL) {
+				return show_di->menu_title;
+			}
+			if (show_di->format_name != NULL) {
+				return show_di->format_name;
+			}
+		}
+	}
+	if (di->menu_title != NULL) {
+		return di->menu_title;
+	}
+	if (di->format_name != NULL) {
+		return di->format_name;
+	}
+	return NULL;
+}
+
+/*
+ * search_add_item - add an item to the search list and listbox
+ */
+static void search_add_item(DATA_INFO *di, const TCHAR *title)
+{
+	DATA_INFO **new_items;
+
+	if (title == NULL || *title == TEXT('\0')) {
+		return;
+	}
+	// Grow array if needed
+	if (search_item_count >= search_item_capacity) {
+		search_item_capacity *= 2;
+		new_items = (DATA_INFO **)mem_alloc(sizeof(DATA_INFO *) * search_item_capacity);
+		if (new_items == NULL) {
+			return;
+		}
+		CopyMemory(new_items, search_items, sizeof(DATA_INFO *) * search_item_count);
+		mem_free((void **)&search_items);
+		search_items = new_items;
+	}
+	search_items[search_item_count] = di;
+	search_item_count++;
+	SendMessage(hListBox, LB_ADDSTRING, 0, (LPARAM)title);
+}
+
+/*
+ * search_collect - recursively collect matching items from history
+ */
+static void search_collect(DATA_INFO *di, const TCHAR *filter)
+{
+	TCHAR *title;
+
+	for (; di != NULL; di = di->next) {
+		if (di->type == TYPE_FOLDER) {
+			// Recurse into folders
+			if (di->child != NULL) {
+				search_collect(di->child, filter);
+			}
+			continue;
+		}
+		// Skip separators
+		if (di->title != NULL && lstrcmp(di->title, TEXT("-")) == 0) {
+			continue;
+		}
+		title = search_get_title(di);
+		if (title == NULL) {
+			continue;
+		}
+		// Match filter (empty filter matches all)
+		if (*filter == TEXT('\0') || StrStrI(title, filter) != NULL) {
+			search_add_item(di, title);
+		}
+	}
+}
+
+/*
+ * search_populate - populate listbox with filtered items
+ */
+static void search_populate(const TCHAR *filter)
+{
+	SendMessage(hListBox, LB_RESETCONTENT, 0, 0);
+	search_item_count = 0;
+	search_collect(search_history_root, filter);
+	if (search_item_count > 0) {
+		SendMessage(hListBox, LB_SETCURSEL, 0, 0);
+	}
+}
+
+/*
+ * search_select_item - select the current listbox item and close
+ */
+static void search_select_item(void)
+{
+	int sel;
+
+	sel = (int)SendMessage(hListBox, LB_GETCURSEL, 0, 0);
+	if (sel >= 0 && sel < search_item_count) {
+		search_result = search_items[sel];
+	} else {
+		search_result = NULL;
+	}
+	DestroyWindow(hSearchWnd);
+}
+
+/*
+ * listbox_subproc - subclassed listbox for vi-style keys
+ */
+static LRESULT CALLBACK listbox_subproc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
+{
+	int sel, count;
+
+	switch (msg) {
+	case WM_KEYDOWN:
+		switch (wParam) {
+		case VK_RETURN:
+			search_select_item();
+			return 0;
+
+		case VK_ESCAPE:
+			search_result = NULL;
+			DestroyWindow(hSearchWnd);
+			return 0;
+
+		case VK_OEM_2:
+			// '/' key - focus search edit
+			SetFocus(hEditCtrl);
+			return 0;
+		}
+		break;
+
+	case WM_CHAR:
+		switch (wParam) {
+		case TEXT('j'):
+			// Move down
+			count = (int)SendMessage(hWnd, LB_GETCOUNT, 0, 0);
+			sel = (int)SendMessage(hWnd, LB_GETCURSEL, 0, 0);
+			if (sel < count - 1) {
+				SendMessage(hWnd, LB_SETCURSEL, sel + 1, 0);
+			}
+			return 0;
+
+		case TEXT('k'):
+			// Move up
+			sel = (int)SendMessage(hWnd, LB_GETCURSEL, 0, 0);
+			if (sel > 0) {
+				SendMessage(hWnd, LB_SETCURSEL, sel - 1, 0);
+			}
+			return 0;
+
+		case TEXT('g'):
+			// Go to top
+			SendMessage(hWnd, LB_SETCURSEL, 0, 0);
+			return 0;
+
+		case TEXT('G'):
+			// Go to bottom
+			count = (int)SendMessage(hWnd, LB_GETCOUNT, 0, 0);
+			if (count > 0) {
+				SendMessage(hWnd, LB_SETCURSEL, count - 1, 0);
+			}
+			return 0;
+
+		case TEXT('/'):
+			// Consumed (handled in WM_KEYDOWN)
+			return 0;
+		}
+		break;
+
+	case WM_LBUTTONDBLCLK:
+		search_select_item();
+		return 0;
+	}
+	return CallWindowProc(origListBoxProc, hWnd, msg, wParam, lParam);
+}
+
+/*
+ * edit_subproc - subclassed edit control for navigation keys
+ */
+static LRESULT CALLBACK edit_subproc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
+{
+	int sel, count;
+
+	switch (msg) {
+	case WM_KEYDOWN:
+		switch (wParam) {
+		case VK_RETURN:
+			search_select_item();
+			return 0;
+
+		case VK_ESCAPE:
+			search_result = NULL;
+			DestroyWindow(hSearchWnd);
+			return 0;
+
+		case VK_DOWN:
+			// Move selection down in listbox
+			count = (int)SendMessage(hListBox, LB_GETCOUNT, 0, 0);
+			sel = (int)SendMessage(hListBox, LB_GETCURSEL, 0, 0);
+			if (sel < count - 1) {
+				SendMessage(hListBox, LB_SETCURSEL, sel + 1, 0);
+			} else if (sel == -1 && count > 0) {
+				SendMessage(hListBox, LB_SETCURSEL, 0, 0);
+			}
+			return 0;
+
+		case VK_UP:
+			// Move selection up in listbox
+			sel = (int)SendMessage(hListBox, LB_GETCURSEL, 0, 0);
+			if (sel > 0) {
+				SendMessage(hListBox, LB_SETCURSEL, sel - 1, 0);
+			}
+			return 0;
+		}
+		break;
+	}
+	return CallWindowProc(origEditProc, hWnd, msg, wParam, lParam);
+}
+
+/*
+ * search_proc - search popup window procedure
+ */
+static LRESULT CALLBACK search_proc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam)
+{
+	TCHAR buf[BUF_SIZE];
+	int client_w, client_h;
+	int edit_h;
+
+	switch (msg) {
+	case WM_CREATE:
+		client_w = SEARCH_WIDTH - SEARCH_MARGIN * 2;
+		edit_h = SEARCH_EDIT_HEIGHT;
+		client_h = SEARCH_HEIGHT;
+
+		// Create edit control (search box)
+		hEditCtrl = CreateWindowEx(0, TEXT("EDIT"), TEXT(""),
+			WS_CHILD | WS_VISIBLE | WS_BORDER | ES_AUTOHSCROLL,
+			SEARCH_MARGIN, SEARCH_MARGIN,
+			client_w, edit_h,
+			hWnd, (HMENU)IDC_SEARCH_EDIT, hInst, NULL);
+
+		// Create listbox (results)
+		hListBox = CreateWindowEx(0, TEXT("LISTBOX"), TEXT(""),
+			WS_CHILD | WS_VISIBLE | WS_BORDER | WS_VSCROLL |
+			LBS_NOTIFY | LBS_NOINTEGRALHEIGHT,
+			SEARCH_MARGIN, SEARCH_MARGIN + edit_h + SEARCH_MARGIN,
+			client_w, client_h - edit_h - SEARCH_MARGIN * 3,
+			hWnd, (HMENU)IDC_SEARCH_LIST, hInst, NULL);
+
+		// Set font
+		hSearchFont = search_create_font();
+		if (hSearchFont != NULL) {
+			SendMessage(hEditCtrl, WM_SETFONT, (WPARAM)hSearchFont, TRUE);
+			SendMessage(hListBox, WM_SETFONT, (WPARAM)hSearchFont, TRUE);
+		}
+
+		// Subclass controls
+		origListBoxProc = (WNDPROC)SetWindowLongPtr(hListBox, GWLP_WNDPROC, (LONG_PTR)listbox_subproc);
+		origEditProc = (WNDPROC)SetWindowLongPtr(hEditCtrl, GWLP_WNDPROC, (LONG_PTR)edit_subproc);
+
+		// Allocate search items array
+		search_item_capacity = SEARCH_INIT_CAPACITY;
+		search_items = (DATA_INFO **)mem_alloc(sizeof(DATA_INFO *) * search_item_capacity);
+		search_item_count = 0;
+
+		// Populate with all items
+		search_populate(TEXT(""));
+
+		// Focus on edit
+		SetFocus(hEditCtrl);
+		break;
+
+	case WM_COMMAND:
+		if (LOWORD(wParam) == IDC_SEARCH_EDIT && HIWORD(wParam) == EN_CHANGE) {
+			// Filter changed - repopulate
+			GetWindowText(hEditCtrl, buf, BUF_SIZE);
+			search_populate(buf);
+		}
+		if (LOWORD(wParam) == IDC_SEARCH_LIST && HIWORD(wParam) == LBN_DBLCLK) {
+			search_select_item();
+		}
+		break;
+
+	case WM_ACTIVATE:
+		if (LOWORD(wParam) == WA_INACTIVE) {
+			// Lost focus - close like a menu
+			search_result = NULL;
+			DestroyWindow(hWnd);
+		}
+		break;
+
+	case WM_DESTROY:
+		// Restore subclassed wndprocs
+		if (hListBox != NULL && origListBoxProc != NULL) {
+			SetWindowLongPtr(hListBox, GWLP_WNDPROC, (LONG_PTR)origListBoxProc);
+		}
+		if (hEditCtrl != NULL && origEditProc != NULL) {
+			SetWindowLongPtr(hEditCtrl, GWLP_WNDPROC, (LONG_PTR)origEditProc);
+		}
+		// Free resources
+		if (search_items != NULL) {
+			mem_free((void **)&search_items);
+		}
+		search_item_count = 0;
+		search_item_capacity = 0;
+		if (hSearchFont != NULL) {
+			DeleteObject(hSearchFont);
+			hSearchFont = NULL;
+		}
+		hEditCtrl = NULL;
+		hListBox = NULL;
+		origListBoxProc = NULL;
+		origEditProc = NULL;
+		hSearchWnd = NULL;
+		PostQuitMessage(0);
+		break;
+
+	default:
+		return DefWindowProc(hWnd, msg, wParam, lParam);
+	}
+	return 0;
+}
+
+/*
+ * search_popup_show - show search popup and return selected item
+ */
+DATA_INFO *search_popup_show(const HWND hWnd, DATA_INFO *history_root)
+{
+	POINT pos;
+	MSG msg;
+	int x, y;
+	int screen_w, screen_h;
+
+	search_history_root = history_root;
+	search_result = NULL;
+
+	// Position at cursor
+	GetCursorPos(&pos);
+	x = pos.x;
+	y = pos.y;
+
+	// Clamp to screen
+	screen_w = GetSystemMetrics(SM_CXSCREEN);
+	screen_h = GetSystemMetrics(SM_CYSCREEN);
+	if (x + SEARCH_WIDTH > screen_w) {
+		x = screen_w - SEARCH_WIDTH;
+	}
+	if (y + SEARCH_HEIGHT > screen_h) {
+		y = screen_h - SEARCH_HEIGHT;
+	}
+	if (x < 0) x = 0;
+	if (y < 0) y = 0;
+
+	// Create search popup
+	hSearchWnd = CreateWindowEx(
+		WS_EX_TOOLWINDOW | WS_EX_TOPMOST,
+		SEARCH_WND_CLASS, TEXT(""),
+		WS_POPUP | WS_BORDER,
+		x, y, SEARCH_WIDTH, SEARCH_HEIGHT,
+		hWnd, NULL, hInst, NULL);
+
+	if (hSearchWnd == NULL) {
+		return NULL;
+	}
+
+	ShowWindow(hSearchWnd, SW_SHOW);
+	UpdateWindow(hSearchWnd);
+
+	// Modal message loop
+	while (GetMessage(&msg, NULL, 0, 0) == TRUE) {
+		TranslateMessage(&msg);
+		DispatchMessage(&msg);
+	}
+
+	return search_result;
+}
+/* End of source */

--- a/Search.h
+++ b/Search.h
@@ -1,0 +1,23 @@
+/*
+ * CLCL
+ *
+ * Search.h
+ *
+ * Search popup for clipboard history
+ */
+
+#ifndef _INC_SEARCH_H
+#define _INC_SEARCH_H
+
+/* Include Files */
+#include "Data.h"
+
+/* Define */
+#define SEARCH_WND_CLASS				TEXT("CLCLSearch")
+
+/* Function Prototypes */
+BOOL search_regist(const HINSTANCE hInstance);
+DATA_INFO *search_popup_show(const HWND hWnd, DATA_INFO *history_root);
+
+#endif
+/* End of source */

--- a/main.c
+++ b/main.c
@@ -44,6 +44,7 @@
 #include "BinView.h"
 #include "ToolTip.h"
 #include "dpi.h"
+#include "Search.h"
 
 #include "resource.h"
 
@@ -99,6 +100,7 @@ static POINT menu_sel_pt;
 static int menu_sel_top;
 
 static BOOL accel_flag = TRUE;
+static BOOL search_mode_requested = FALSE;
 static BOOL clip_flag;
 static int rechain_cnt;
 
@@ -580,6 +582,29 @@ static BOOL show_popup_menu(const HWND hWnd, const ACTION_INFO *ai, const BOOL c
 	ret = menu_show(hWnd, popup_menu, (caret_flag == TRUE) ? &fi.cpos : NULL);
 	menu_destory(popup_menu);
 	popup_menu = NULL;
+
+	// Search mode: '/' was pressed in menu
+	if (search_mode_requested) {
+		DATA_INFO *search_di;
+		search_mode_requested = FALSE;
+		menu_free();
+		search_di = search_popup_show(hWnd, history_data.child);
+		if (search_di != NULL) {
+			set_focus_info(&fi);
+			SendMessage(hWnd, WM_ITEM_TO_CLIPBOARD, 0, (LPARAM)search_di);
+			if (ai->paste == 1 && GetKeyState(VK_SHIFT) >= 0) {
+				key_wait();
+				unregist_hotkey(hWnd);
+				sendkey_paste(fi.active_wnd);
+				regist_hotkey(hWnd, FALSE);
+			}
+		} else {
+			if (GetForegroundWindow() == hWnd) {
+				set_focus_info(&fi);
+			}
+		}
+		return TRUE;
+	}
 
 	mii = menu_get_info(ret);
 	if (ret <= 0 || ret == IDCANCEL || mii == NULL) {
@@ -1448,6 +1473,11 @@ static LRESULT CALLBACK main_proc(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lPa
 	case WM_MENUCHAR:
 		// メニューアクセラレータ
 		if (HIWORD(wParam) == MF_POPUP) {
+			if ((TCHAR)LOWORD(wParam) == TEXT('/')) {
+				// Switch to search mode
+				search_mode_requested = TRUE;
+				return MAKELRESULT(0, MNC_CLOSE);
+			}
 			return menu_accelerator((HMENU)lParam, (TCHAR)LOWORD(wParam));
 		}
 		break;
@@ -2397,7 +2427,8 @@ int WINAPI _tWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPTSTR lpCmdL
 
 	// ビューアの登録
 	if (viewer_regist(hInstance) == FALSE ||
-		container_regist(hInstance) == FALSE || binview_regist(hInstance) == FALSE) {
+		container_regist(hInstance) == FALSE || binview_regist(hInstance) == FALSE ||
+		search_regist(hInstance) == FALSE) {
 		MessageBox(NULL, message_get_res(IDS_ERROR_WINDOW_INIT), ERROR_TITLE, MB_ICONERROR);
 		if (hMutex != NULL) {
 			CloseHandle(hMutex);

--- a/scripts/build-wsl.sh
+++ b/scripts/build-wsl.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+#
+# Build the CLCL Win32 binaries from WSL by driving the Windows MSBuild.
+#
+# Runs standalone (./scripts/build-wsl.sh) or via `make build-wsl`, which
+# exports the same knobs as environment variables.
+#
+# One workaround is baked in: mt.exe cannot embed res/manifest.xml when the
+# sources sit on a \\wsl.localhost UNC path (error c1010070 -> LNK1327). The
+# tree is therefore mirrored to a drive-local directory and built there, with
+# the artifacts copied back afterwards.
+#
+# TOOLSET and SDK are empty by default - the .vcxproj files decide. Set them to
+# build against something else, e.g. TOOLSET=v145, or TOOLSET=v141_xp SDK=7.0
+# to restore the original XP-targeting configuration on a machine that has it.
+#
+# WSL<->Windows interop here intermittently refuses to launch Windows processes
+# ("UtilAcceptVsock:273: accept4 failed 110") and recovers on its own after
+# some seconds, so the build waits for it rather than failing outright.
+
+set -euo pipefail
+
+CONFIG="${CONFIG:-Release}"
+PLATFORM="${PLATFORM:-x86}"
+TOOLSET="${TOOLSET:-}"
+SDK="${SDK:-}"
+WIN_BUILD="${WIN_BUILD:-/mnt/c/temp/clcl-build}"
+VSWHERE="${VSWHERE:-/mnt/c/Program Files (x86)/Microsoft Visual Studio/Installer/vswhere.exe}"
+INTEROP_TRIES="${INTEROP_TRIES:-12}"
+INTEROP_DELAY="${INTEROP_DELAY:-5}"
+BUILD_TRIES="${BUILD_TRIES:-3}"
+# Word splitting is intended - this arrives from make as a plain string.
+# shellcheck disable=SC2206
+ARTIFACTS=(${ARTIFACTS:-CLCL.exe CLCLHook.dll CLCLSet.exe})
+
+die() {
+	echo "build-wsl: $*" >&2
+	exit 1
+}
+
+# Block until a Windows process will actually start, so a flaky interop shows up
+# as a wait instead of a bogus "MSBuild not found" or a half-finished build.
+wait_for_interop() {
+	local attempt
+	for attempt in $(seq 1 "$INTEROP_TRIES"); do
+		if "$VSWHERE" -help >/dev/null 2>&1; then
+			return 0
+		fi
+		echo "==> WSL interop not responding, retrying ($attempt/$INTEROP_TRIES)"
+		sleep "$INTEROP_DELAY"
+	done
+	return 1
+}
+
+find_msbuild() {
+	"$VSWHERE" -latest -products '*' -requires Microsoft.Component.MSBuild \
+		-find 'MSBuild\**\Bin\MSBuild.exe' 2>/dev/null | tr -d '\r' | head -n1
+}
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+[ -x "$VSWHERE" ] || die 'vswhere.exe not found - is Visual Studio installed?'
+
+wait_for_interop \
+	|| die "WSL interop still down after $((INTEROP_TRIES * INTEROP_DELAY))s - try 'wsl --shutdown' from Windows."
+
+msbuild="$(find_msbuild)"
+[ -n "$msbuild" ] \
+	|| die 'MSBuild not found - install the "Desktop development with C++" workload.'
+msbuild="$(wslpath -u "$msbuild")"
+echo "==> msbuild: $msbuild"
+
+echo "==> mirroring to $WIN_BUILD"
+mkdir -p "$WIN_BUILD"
+# Release/ and Debug/ are excluded from --delete too, which keeps the mirror's
+# object files around so repeat builds stay incremental.
+rsync -a --delete \
+	--exclude='.git/' --exclude='.claude/' \
+	--exclude='Release/' --exclude='Debug/' --exclude='.vs/' \
+	./ "$WIN_BUILD/"
+
+props=(-p:Configuration="$CONFIG" -p:Platform="$PLATFORM")
+if [ -n "$TOOLSET" ]; then
+	props+=(-p:PlatformToolset="$TOOLSET")
+fi
+if [ -n "$SDK" ]; then
+	props+=(-p:WindowsTargetPlatformVersion="$SDK")
+fi
+
+run_msbuild() {
+	(
+		cd "$WIN_BUILD"
+		"$msbuild" CLCL.sln "${props[@]}" -m -v:minimal -nologo
+	)
+}
+
+# Interop can also drop the MSBuild launch itself, after the check above passed.
+# Only that failure is retried - a real build error fails on the first attempt.
+log="$(mktemp)"
+trap 'rm -f "$log"' EXIT
+
+for attempt in $(seq 1 "$BUILD_TRIES"); do
+	if run_msbuild 2>&1 | tee "$log"; then
+		break
+	fi
+	if ! grep -q 'UtilAcceptVsock' "$log"; then
+		die 'build failed'
+	fi
+	if [ "$attempt" -eq "$BUILD_TRIES" ]; then
+		die "WSL interop dropped the MSBuild launch $BUILD_TRIES times - try 'wsl --shutdown' from Windows."
+	fi
+	echo "==> WSL interop dropped the MSBuild launch, retrying ($attempt/$BUILD_TRIES)"
+	wait_for_interop \
+		|| die "WSL interop still down - try 'wsl --shutdown' from Windows."
+done
+
+mkdir -p "$CONFIG"
+for a in "${ARTIFACTS[@]}"; do
+	cp -f "$WIN_BUILD/$CONFIG/$a" "$CONFIG/"
+done
+
+echo "==> $CONFIG/"
+ls -l "${ARTIFACTS[@]/#/$CONFIG/}"


### PR DESCRIPTION
Hitting `/` in the history popup menu now opens a little search box instead of
just beeping at you. Type to filter, and the list narrows as you go.

Keys:
- `j` / `k` or arrows — move up/down
- `g` / `G` — jump to top/bottom
- `/` — back to the edit box to refine the query
- `Enter` — copy (and paste, if you have auto-paste on)
- `Esc` — bail out

<img width="397" height="426" alt="image" src="https://github.com/user-attachments/assets/12712a43-d5a0-43a3-a196-7274b197ebcb" />
