### PR TITLE
Remove Windows version checks for NT platform detection

### DIFF
--- a/fmt_Bitmap.c
+++ b/fmt_Bitmap.c
@@ -404,7 +404,6 @@ __declspec(dllexport) BOOL CALLBACK bitmap_get_menu_bitmap(DATA_INFO *di, const 
 	HBITMAP old_to_hbmp;
 	BITMAP bmp;
 	BYTE *mem;
-	OSVERSIONINFO osvi;
 
 	if (di->data == NULL) {
 		return FALSE;
@@ -433,11 +432,7 @@ __declspec(dllexport) BOOL CALLBACK bitmap_get_menu_bitmap(DATA_INFO *di, const 
 	di->free_bitmap = TRUE;
 	old_to_hbmp = SelectObject(to_dc, di->menu_bitmap);
 
-	//OSバージョンのチェック
-	osvi.dwOSVersionInfoSize = sizeof(OSVERSIONINFO);
-	GetVersionEx(&osvi);
-	if (osvi.dwPlatformId == VER_PLATFORM_WIN32_NT &&
-		(width < bmp.bmWidth || height < bmp.bmHeight)) {
+	if (width < bmp.bmWidth || height < bmp.bmHeight) {
 		SetStretchBltMode(to_dc, HALFTONE);
 		SetBrushOrgEx(to_dc, 0, 0, NULL);
 	} else {

--- a/fmt_file_view.c
+++ b/fmt_file_view.c
@@ -112,24 +112,15 @@ HDROP create_dropfile(const TCHAR **FileName, const int cnt, DWORD *ret_size)
 {
 	HDROP hDrop;
 	LPDROPFILES lpDropFile;
-	OSVERSIONINFO os_info;
 #ifndef UNICODE
 	wchar_t wbuf[BUF_SIZE];
 #endif
 	TCHAR *buf;
-	BOOL fWide = FALSE;
+	BOOL fWide = TRUE;
 	int flen = 0;
 	int i;
 
-	// OSのバージョン取得
-	os_info.dwOSVersionInfoSize = sizeof(OSVERSIONINFO);
-	GetVersionEx(&os_info);
-	if (os_info.dwPlatformId == VER_PLATFORM_WIN32_NT) {
-		fWide = TRUE;
-	}
-
 #ifdef UNICODE
-	fWide = TRUE;
 	for (i = 0; i < cnt; i++) {
 		flen += (lstrlen(*(FileName + i)) + 1) * sizeof(TCHAR);
 	}


### PR DESCRIPTION
## Summary
This PR removes obsolete Windows version detection code that checked for Windows NT platform using `GetVersionEx()` and `VER_PLATFORM_WIN32_NT`. These checks are no longer necessary as the codebase now targets modern Windows versions exclusively.

## Key Changes
- **fmt_file_view.c**: Removed `OSVERSIONINFO` structure and `GetVersionEx()` call that conditionally set `fWide = TRUE` for NT platforms. Changed default `fWide` initialization from `FALSE` to `TRUE` and removed the redundant assignment in the `#ifdef UNICODE` block.
- **fmt_Bitmap.c**: Removed `OSVERSIONINFO` structure and `GetVersionEx()` call that conditionally applied `SetStretchBltMode()` only on NT platforms. The stretch mode is now applied unconditionally when bitmap dimensions require it.

## Implementation Details
- The `fWide` flag now defaults to `TRUE`, reflecting that wide character support is always enabled in modern Windows environments.
- The bitmap stretch mode logic is simplified by removing the platform check, as the functionality is safe to use on all supported Windows versions.
- These changes eliminate deprecated API usage (`GetVersionEx()` is deprecated as of Windows 8.1) and reduce code complexity.